### PR TITLE
Improve performance

### DIFF
--- a/lib/cssminify2/cssmin.rb
+++ b/lib/cssminify2/cssmin.rb
@@ -306,12 +306,13 @@ module CssCompressor
     #
     if linebreakpos
       startIndex = 0
-      i = 0
+      i = linebreakpos
       while i < css.length
         i = i + 1
         if css[i - 1] === '}' && i - startIndex > linebreakpos
           css = css.slice(0, i) + "\n" + css.slice(i, css.length - i)
           startIndex = i
+          i = startIndex + linebreakpos
         end
       end
     end


### PR DESCRIPTION
There's a loop that spends a lot of time just incrementing `i` by `1` when it's known that nothing will happen for the first `5000` steps. Let's just do those 5000 steps all at once immediately.

PS: I don't know Ruby actually, please double-check that it makes sense. As for performance, when building my jekyll blog it currently spends several minutes minimizing one CSS file, mostly due to this sloppily written loop.